### PR TITLE
add-node-polyfills

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,32 @@
+/**
+ * This is the build script for the project.
+ *
+ * It takes the source code and bundles it into a single file
+ * that can be imported into an inlang project.
+ */
+
+import { build } from "esbuild";
+import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outfile: "dist/index.js",
+  bundle: true,
+  // minification is disabled in dev mode for better debugging
+  minify: process.env.DEV ? false : true,
+  watch: process.env.DEV ? true : false,
+  format: "esm",
+  platform: "browser",
+  target: "es2020",
+  plugins: [
+    // by default node polyfills are included
+    // as a lot of npm packages that deal with files
+    // use built-in node modules
+    NodeModulesPolyfillPlugin(),
+  ],
+});
+
+console.log("✅ build complete");
+if (process.env.DEV) {
+  console.log("👀 watching for changes...");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@inlang/core": "^0.3.0"
       },
       "devDependencies": {
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "concurrently": "^7.6.0",
         "esbuild": "^0.16.11",
         "husky": "^8.0.3",
@@ -18,6 +19,19 @@
       },
       "engines": {
         "node": "^18"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -666,6 +680,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -798,6 +830,15 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/memfs": {
@@ -958,6 +999,36 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
@@ -1003,6 +1074,13 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -1325,6 +1403,16 @@
     }
   },
   "dependencies": {
+    "@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.16.11",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.11.tgz",
@@ -1695,6 +1783,18 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "fs-monkey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
@@ -1787,6 +1887,15 @@
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "memfs": {
@@ -1910,6 +2019,35 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "requires": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "rxjs": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
@@ -1946,6 +2084,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spawn-command": {
       "version": "0.0.2-1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:watch\" \"npm run dev:test\"",
     "dev:test": "vitest",
-    "dev:watch": "esbuild ./src/index.ts --bundle --platform=browser --format=esm --minify --outfile=./dist/index.js --watch",
-    "build": "esbuild ./src/index.ts --bundle --platform=browser --format=esm --minify --outfile=./dist/index.js",
+    "dev:watch": "DEV=true node ./build.js",
+    "build": "node ./build.js",
     "test": "vitest run",
     "prepare": "husky install"
   },
@@ -17,6 +17,7 @@
     "@inlang/core": "^0.3.0"
   },
   "devDependencies": {
+    "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "concurrently": "^7.6.0",
     "esbuild": "^0.16.11",
     "husky": "^8.0.3",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { initializeConfig } from "../example/inlang.config.js";
+import { defineConfig } from "../example/inlang.config.js";
 import { describe, it, expect } from "vitest";
 import nodeFs from "node:fs";
 import { fs as memfs } from "memfs";
@@ -11,7 +11,7 @@ import {
 import { query } from "@inlang/core/query";
 
 const env = await initializeTestEnvironment();
-const config = (await initializeConfig(env)) as Config;
+const config: Config = await defineConfig(env);
 
 describe("plugin", async () => {
   const resources = await config.readResources({ config });
@@ -94,7 +94,7 @@ async function initializeTestEnvironment(): Promise<EnvironmentFunctions> {
     await $fs.mkdir(path, { recursive: true });
 
     for (const file of await nodeFs.promises.readdir("./" + path)) {
-      const isFile = file.indexOf('.') > -1
+      const isFile = file.indexOf(".") > -1;
       if (isFile) {
         await $fs.writeFile(
           `${path}/${file}`,
@@ -102,14 +102,14 @@ async function initializeTestEnvironment(): Promise<EnvironmentFunctions> {
           { encoding: "utf-8" }
         );
       } else {
-        await copyDirectory(`${path}/${file}`)
-      };
+        await copyDirectory(`${path}/${file}`);
+      }
     }
-  }
+  };
 
   // only /dist and /example are needed and therefore copied
   for (const path of ["/dist", "/example"]) {
-    await copyDirectory(path)
+    await copyDirectory(path);
   }
 
   return env;


### PR DESCRIPTION
A lot of plugins (will) use npm libraries that call node built-ins like process. Adding node polyfills to the template seems like a sensible default. 

The polyfills get tree shaking if not used by esbuild.